### PR TITLE
allow hyphen as last symbol in template name

### DIFF
--- a/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
+++ b/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java
@@ -56,7 +56,7 @@ public final class AzureUtil {
 
     public static final String VAL_ADMIN_USERNAME = "([a-zA-Z0-9_-]{3,15})";
 
-    public static final String VAL_TEMPLATE = "^[a-z][a-z0-9-]*[a-z0-9]$";
+    public static final String VAL_TEMPLATE = "^[a-z][a-z0-9-]*[a-z0-9-]$";
 
     public static final int STORAGE_ACCOUNT_MIN_LENGTH = 3;
     public static final int STORAGE_ACCOUNT_MAX_LENGTH = 24;


### PR DESCRIPTION
Plugin configuration has a field for agent template name, that requires value to end with alphanumeric:
![image](https://github.com/jenkinsci/azure-vm-agents-plugin/assets/322967/dda22291-dbb7-4ee0-9f94-e99a46b1a634)

That results in agent node name being `cloud-ci-agenta1b2c3`, which is not well-readable.
Regex that is validating the value:
https://github.com/jenkinsci/azure-vm-agents-plugin/blob/ed57d5c88d6941591d32460ab8f7c79c1ed37838/src/main/java/com/microsoft/azure/vmagent/util/AzureUtil.java#L59

At the same time, agent we also have that are provisioned by other means, are having names like e.g. `cloud-tf-agent-a1b2c3`, meaning Azure accepts agent template name suffixed with hyphen. 




### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
